### PR TITLE
Remove deprecated "node-role.kubernetes.io/master"

### DIFF
--- a/templates/values.j2
+++ b/templates/values.j2
@@ -34,10 +34,10 @@ mountPath: "/data"
 # -- INGRESS --
 ingress:
   enabled: true
+  ingressClassName: nginx
   hosts:
   - {{ public_hostname_api }}
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: {{ ingress_certmanager_issuer }}
   tls:
   - hosts:

--- a/templates/values.j2
+++ b/templates/values.j2
@@ -76,21 +76,16 @@ resources:
 
 {% if master_deploy %}
 tolerations:
-- key: node-role.kubernetes.io/master
-  operator: Exists
-  effect: NoSchedule
 - key: node-role.kubernetes.io/control-plane
   operator: Exists
   effect: NoSchedule
 nodeSelector:
-  node-role.kubernetes.io/master: ''
+  node-role.kubernetes.io/control-plane: ''
 
 makeUserJob:
  tolerations:
- - key: node-role.kubernetes.io/master
-   effect: NoSchedule
  - key: node-role.kubernetes.io/control-plane
    effect: NoSchedule
  nodeSelector:
-   node-role.kubernetes.io/master: ''
+   node-role.kubernetes.io/control-plane: ''
 {% endif %}


### PR DESCRIPTION
Since version 1.20 the correct master node label is: `node-role.kubernetes.io/control-plane`.
Since version 1.24 `node-role.kubernetes.io/master` has been removed, so the the pods always remain in pending.